### PR TITLE
Add task update_index

### DIFF
--- a/lib/redmine_postgresql_search.rb
+++ b/lib/redmine_postgresql_search.rb
@@ -63,6 +63,10 @@ module RedminePostgresqlSearch
       @searchables.each(&:rebuild_index)
     end
 
+    def update_indices
+      @searchables.each(&:update_index)
+    end
+
     private
 
     def setup_searchable(clazz, options = {})

--- a/lib/redmine_postgresql_search/patches/searchable.rb
+++ b/lib/redmine_postgresql_search/patches/searchable.rb
@@ -14,6 +14,15 @@ module RedminePostgresqlSearch
           raise e
         end
 
+        def update_index
+          find_in_batches.each do |group|
+            group.each(&:update_fulltext_index)
+          end
+        rescue StandardError => e
+          logger.error("update index failed for searchable type #{name}")
+          raise e
+        end
+
         # Build search queries for searchable type.
         # Can return multiple queries when journals, attachments and custom fields are searched, too.
         # The queries expect a CTE called 'fts' which returns a searchable_type and a searchable_id.

--- a/lib/tasks/redmine_postgresql_search.rake
+++ b/lib/tasks/redmine_postgresql_search.rake
@@ -1,6 +1,11 @@
 namespace :redmine_postgresql_search do
-  desc 'reindexes all searchable models'
+  desc 'Reindexes all searchable models (delete/create)'
   task rebuild_index: :environment do
     RedminePostgresqlSearch.rebuild_indices
+  end
+
+  desc 'Updates search index for all searchable models'
+  task update_index: :environment do
+    RedminePostgresqlSearch.update_indices
   end
 end


### PR DESCRIPTION
A variant of rebuild_index that does not delete all rows first and can run
concurrently with writes from Redmine without blocking too long.

Can be used after a `TRUNCATE fulltext_words; TRUNCATE fulltext_indices;`
to build a new search index from scratch.